### PR TITLE
Elf corrections

### DIFF
--- a/source/STM32firmware/PlusCart/Src/cartridge_emulation_ELF.c
+++ b/source/STM32firmware/PlusCart/Src/cartridge_emulation_ELF.c
@@ -99,23 +99,29 @@ int launch_elf_file(const char* filename, uint32_t buffer_size, uint8_t* buffer)
 	SectionMetaEntry* meta = malloc(sizeof(SectionMetaEntry) * metaCount);
 	if (!initSectionsMeta(buffer, meta, (uint32_t)CCM_RAM))
 	{
+		exit_cartridge(0x1100, 0x1000);
 		return 0;
 	}
 	if (!loadElf(buffer, metaCount, meta, &pMainAddress, &usesVcsWrite3))
 	{
+		exit_cartridge(0x1100, 0x1000);
 		return 0;
 	}
+
 	runPreInitFuncs(metaCount, meta);
 	runInitFuncs(metaCount, meta);
 
 	if(usesVcsWrite3)
 		vcsInitBusStuffing();
+
 	vcsEndOverblank();
 	vcsNop2n(1024);
 
 	// Run game
 	((void (*)())pMainAddress)(mainArgs);
+
 	// elf rom should have jumped to 0x1000 and put nop on bus
 	exit_cartridge(0x1100, 0x1000);
+
 	return 1;
 }

--- a/source/STM32firmware/PlusCart/Src/esp8266.c
+++ b/source/STM32firmware/PlusCart/Src/esp8266.c
@@ -21,7 +21,7 @@
 #include <stdio.h>
 #include <string.h>
 #include "stm32_udid.h"
-#include "esp8266_AT_WifiManager.h"
+#include "esp8266_AT_WiFiManager.h"
 #include "esp8266.h"
 #include "md5.h"
 #include "flash.h"


### PR DESCRIPTION
When working on the issues described in https://github.com/Al-Nafuur/United-Carts-of-Atari/issues/8 I made some changes to the firmware to help find the reason for the problem.

These are the commits that remain relevant now that the solution has been found.

1) the project is now compilable on UNIX like operating systems
2) a bad ELF file that cannot be loaded correctly will cause the PlusCart to return to the main menu