### PR TITLE
Add vcsWrite4() to ELF lib support

### DIFF
--- a/source/STM32firmware/PlusCart/Inc/vcsLib.h
+++ b/source/STM32firmware/PlusCart/Inc/vcsLib.h
@@ -116,6 +116,7 @@ void vcsLdaForBusStuff2();
 void vcsLdxForBusStuff2();
 void vcsLdyForBusStuff2();
 void vcsWrite3(uint8_t ZP, uint8_t data);
+void vcsWrite4(uint16_t address, uint8_t data);
 
 void vcsJmp3(); // jmp $f000 - used to keep PC in range of ROM. Call this when there are spare cycles to kill
 

--- a/source/STM32firmware/PlusCart/Src/cartridge_emulation_ELF.c
+++ b/source/STM32firmware/PlusCart/Src/cartridge_emulation_ELF.c
@@ -30,6 +30,7 @@ NameAddressMapEntry NameAddressMap[] = {
 	{(uint32_t)vcsLdxForBusStuff2, "vcsLdxForBusStuff2" },
 	{(uint32_t)vcsLdyForBusStuff2, "vcsLdyForBusStuff2" },
 	{(uint32_t)vcsWrite3, "vcsWrite3" },
+	{(uint32_t)vcsWrite4, "vcsWrite4" },
 	{(uint32_t)vcsJmp3, "vcsJmp3" },
 	{(uint32_t)vcsNop2, "vcsNop2" },
 	{(uint32_t)vcsNop2n, "vcsNop2n" },
@@ -93,7 +94,7 @@ int launch_elf_file(const char* filename, uint32_t buffer_size, uint8_t* buffer)
 	if(mainArgs[MP_SYSTEM_TYPE] == ST_PAL_2600 || mainArgs[MP_SYSTEM_TYPE] == ST_PAL60_2600)
 		NameAddressMap[0].address = (uint32_t)&Pal2600[0];
 
-	int usesVcsWrite3;
+	int usesBusStuffing;
 	uint32_t pMainAddress;
 	uint32_t metaCount = ((ElfHeader*)buffer)->e_shnum;
 	SectionMetaEntry* meta = malloc(sizeof(SectionMetaEntry) * metaCount);
@@ -102,7 +103,7 @@ int launch_elf_file(const char* filename, uint32_t buffer_size, uint8_t* buffer)
 		exit_cartridge(0x1100, 0x1000);
 		return 0;
 	}
-	if (!loadElf(buffer, metaCount, meta, &pMainAddress, &usesVcsWrite3))
+	if (!loadElf(buffer, metaCount, meta, &pMainAddress, &usesBusStuffing))
 	{
 		exit_cartridge(0x1100, 0x1000);
 		return 0;
@@ -111,7 +112,7 @@ int launch_elf_file(const char* filename, uint32_t buffer_size, uint8_t* buffer)
 	runPreInitFuncs(metaCount, meta);
 	runInitFuncs(metaCount, meta);
 
-	if(usesVcsWrite3)
+	if(usesBusStuffing)
 		vcsInitBusStuffing();
 
 	vcsEndOverblank();

--- a/source/STM32firmware/PlusCart/Src/elfLib.c
+++ b/source/STM32firmware/PlusCart/Src/elfLib.c
@@ -95,9 +95,9 @@ int isElf(uint32_t size, uint8_t* buffer) {
 }
 
 // pMainAddress will have bit0 set since it's pointing to a thumb function. Mask bit0 off if looking for physical address of first byte in function
-int loadElf(uint8_t* elfBuffer, uint32_t metaCount, SectionMetaEntry meta[], uint32_t* pMainAddress, int* usesVcsWrite3) {
+int loadElf(uint8_t* elfBuffer, uint32_t metaCount, SectionMetaEntry meta[], uint32_t* pMainAddress, int* usesBusStuffing) {
 	*pMainAddress = 0;
-	*usesVcsWrite3 = 0;
+	*usesBusStuffing = 0;
 	SectionHeader* symTableSectionHeader = 0;
 	ElfHeader* pHeader = (ElfHeader*)elfBuffer;
 
@@ -138,9 +138,9 @@ int loadElf(uint8_t* elfBuffer, uint32_t metaCount, SectionMetaEntry meta[], uin
 				return 0;
 			}
 		}
-		else if (strCmp(name, "vcsWrite3"))
+		else if (strCmp(name, "vcsWrite3") || strCmp(name, "vcsWrite4"))
 		{
-			*usesVcsWrite3 = 1;
+			*usesBusStuffing = 1;
 		}
 	}
 	if (*pMainAddress == 0)

--- a/source/STM32firmware/PlusCart/Src/vcsLib.c
+++ b/source/STM32firmware/PlusCart/Src/vcsLib.c
@@ -394,6 +394,23 @@ void vcsWrite3(uint8_t ZP, uint8_t data)
 	SET_DATA_MODE(modeLookup[data]);
 }
 
+// Uses Bus-Stuffing, requires A,X,Y to be set via vcsLd*ForBusStuff2() functions prior to use and any time those registers are changed.
+__attribute__((long_call, section(".RamFunc")))
+void vcsWrite4(uint16_t address, uint8_t data)
+{
+    InjectRomByte(opcodeLookup[data] + 8); // Adding 8 to the opcode changes the address mode from zero page to absolute.
+    InjectRomByte((uint8_t)address);
+    InjectRomByte((uint8_t)(address >> 8));
+
+	// Stuff in the data over what's there
+	while (address != ADDR_IN)
+		;
+
+	// The full value is written to ODR, but thanks to modeLookup[], only bits that need to be stuffed get driven
+	DATA_OUT = data;
+	SET_DATA_MODE(modeLookup[data]);
+}
+
 __attribute__((long_call, section(".RamFunc")))
 void vcsJmp3()
 {


### PR DESCRIPTION
Added a new vcsLib function

vcsWrite4(uint16_t address, uint8_t data)

It uses bus stuffing to write the data to the address within 4 cycles.
